### PR TITLE
Use the last occurrence of '.' to get the output filename

### DIFF
--- a/helpers/wem2wav.js
+++ b/helpers/wem2wav.js
@@ -9,7 +9,7 @@ exports.wem2wav = wem2wav = async ({
   const vgmstream = path.join(".", "libs", "vgmstream-cli.exe");
   const outputFile = path.join(
     outputDir,
-    createdFile.split(".")[0] + ".wav"
+    createdFile.substr(0, createdFile.lastIndexOf('.')) + ".wav"
   );
   const createdFilePath = path.join(processingDir, createdFile);
 


### PR DESCRIPTION
This was causing two or more files to be written under the same file.

Example:

With the pre-dowloaded 1.3 update, we can see 2 SFX files named like so:

- SFX_1.3_0.pck
- SFX_1.3_1.pck

By using only the first part of the split with `.`, both file would be written with the `SFX_1` name.


This PR would fix it by using everything before the last occurrence of `.`.