### PR TITLE
Bugfixes and OGG audio support

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -23,7 +23,7 @@ const main = async () => {
   const args = arg({
     // Types
     "--input": String,
-    "--audio": arg.flag((val) => ["flac", "mp3", "flacandmp3"].includes(val) ? val : null),
+    "--audio": String,
     "--verbose": arg.COUNT,
 
     // Aliases
@@ -58,16 +58,12 @@ const main = async () => {
         const subWavOutputDir = path.join(".", "output", "WAV", dirName);
         const subFlacOutputDir = path.join(".", "output", "FLAC", dirName);
         const subMp3OutputDir = path.join(".", "output", "MP3", dirName);
+        const subOggOutputDir = path.join(".", "output", "OGG", dirName);
 
         await mkdirp(subWavOutputDir);
 
-        if (args['--audio'] === "flac" || args['--audio'] === "flacandmp3") {
-          await mkdirp(subFlacOutputDir);
-        }
-
-        if (args['--audio'] === "mp3" || args['--audio'] === "flacandmp3") {
-          await mkdirp(subMp3OutputDir);
-        }
+        if (!["mp3", "flac", "ogg", "all"].includes(args['--audio']))
+          console.log(`'${args['--audio']}' is not a valid audio export option, ignoring`)
 
         const createdFiles = fs.readdirSync(processingDir);
 
@@ -83,6 +79,7 @@ const main = async () => {
 
         switch (args['--audio']) {
           case "flac":
+            await mkdirp(subFlacOutputDir);
             await Promise.all(
               createdFiles.map(async (createdFile) => {
                 await wav2flacPool.exec({
@@ -94,6 +91,7 @@ const main = async () => {
             );
             break;
           case "mp3":
+            await mkdirp(subMp3OutputDir);
             await Promise.all(
               createdFiles.map(async (createdFile) => {
                 await wav2mp3Pool.exec({

--- a/helpers/pck2wem.js
+++ b/helpers/pck2wem.js
@@ -1,4 +1,4 @@
-exports.pck2wem = async ({pckFile, processingDir}) => {
+exports.pck2wem = async ({ pckFile, processingDir }) => {
   const path = require("path");
   const util = require("util");
   const exec = util.promisify(require("child_process").execFile);

--- a/helpers/wav2flac.js
+++ b/helpers/wav2flac.js
@@ -3,11 +3,10 @@ exports.wav2flac = async ({outputDir, inputDir, createdFile}) => {
   const util = require("util");
   const exec = util.promisify(require("child_process").execFile);
   const ffmpeg = path.join(".", "libs", "ffmpeg.exe");
-  const outputFile = path.join(
-    outputDir,
-    createdFile.split(".")[0] + ".flac"
-  );
-  const wavFilePath = path.join(inputDir, createdFile.split(".")[0] + ".wav");
+  const fileNameNoExt = createdFile.substr(0, createdFile.lastIndexOf('.'));
+  const pckFileNameNoExt = createdFile.substr(0, createdFile.lastIndexOf('_'));
+  const outputFile = path.join(outputDir, fileNameNoExt + ".flac");
+  const wavFilePath = path.join(inputDir, fileNameNoExt + ".wav");
 
   await exec(ffmpeg, [
     "-i",
@@ -19,8 +18,7 @@ exports.wav2flac = async ({outputDir, inputDir, createdFile}) => {
   ]);
 
   console.log(
-    `${createdFile.split("_")[0]}.pck -> ${createdFile} -> ${createdFile.split(".")[0]}.wav -> ${
-      createdFile.split(".")[0]
+    `${pckFileNameNoExt}.pck -> ${createdFile} -> ${fileNameNoExt}.wav -> ${fileNameNoExt
     }.flac`
   );
 };

--- a/helpers/wav2flac.js
+++ b/helpers/wav2flac.js
@@ -1,4 +1,4 @@
-exports.wav2flac = async ({outputDir, inputDir, createdFile}) => {
+exports.wav2flac = async ({ outputDir, inputDir, createdFile }) => {
   const path = require("path");
   const util = require("util");
   const exec = util.promisify(require("child_process").execFile);

--- a/helpers/wav2mp3.js
+++ b/helpers/wav2mp3.js
@@ -1,14 +1,13 @@
-exports.wav2mp3 = async ({outputDir, inputDir, createdFile}) => {
+exports.wav2mp3 = async ({ outputDir, inputDir, createdFile }) => {
   const path = require("path");
   const util = require("util");
   const exec = util.promisify(require("child_process").execFile);
   const ffmpeg = path.join(".", "libs", "ffmpeg.exe");
-  const outputFile = path.join(
-    outputDir,
-    createdFile.split(".")[0] + ".mp3"
-  );
-  const wavFilePath = path.join(inputDir, createdFile.split(".")[0] + ".wav");
-  
+  const fileNameNoExt = createdFile.substr(0, createdFile.lastIndexOf('.'));
+  const pckFileNameNoExt = createdFile.substr(0, createdFile.lastIndexOf('_'));
+  const outputFile = path.join(outputDir, fileNameNoExt + ".mp3");
+  const wavFilePath = path.join(inputDir, fileNameNoExt + ".wav");
+
   await exec(ffmpeg, [
     "-i",
     wavFilePath,
@@ -21,8 +20,7 @@ exports.wav2mp3 = async ({outputDir, inputDir, createdFile}) => {
   ]);
 
   console.log(
-    `${createdFile.split("_")[0]}.pck -> ${createdFile} -> ${createdFile.split(".")[0]}.wav -> ${
-      createdFile.split(".")[0]
+    `${pckFileNameNoExt}.pck -> ${createdFile} -> ${fileNameNoExt}.wav -> ${fileNameNoExt
     }.mp3`
   );
 };

--- a/helpers/wav2ogg.js
+++ b/helpers/wav2ogg.js
@@ -1,0 +1,28 @@
+exports.wav2ogg = async ({ outputDir, inputDir, createdFile }) => {
+  const path = require("path");
+  const util = require("util");
+  const exec = util.promisify(require("child_process").execFile);
+  const ffmpeg = path.join(".", "libs", "ffmpeg.exe");
+  const fileNameNoExt = createdFile.substr(0, createdFile.lastIndexOf('.'));
+  const pckFileNameNoExt = createdFile.substr(0, createdFile.lastIndexOf('_'));
+  const outputFile = path.join(outputDir, fileNameNoExt + ".ogg");
+  const wavFilePath = path.join(inputDir, fileNameNoExt + ".wav");
+
+  await exec(ffmpeg, [
+    "-i",
+    wavFilePath,
+    "-y",
+    "-ar",
+    "44100",
+    "-acodec",
+    "libvorbis",
+    "-qscale:a",
+    "10",
+    outputFile,
+  ]);
+
+  console.log(
+    `${pckFileNameNoExt}.pck -> ${createdFile} -> ${fileNameNoExt}.wav -> ${fileNameNoExt
+    }.ogg`
+  );
+};

--- a/helpers/wem2wav.js
+++ b/helpers/wem2wav.js
@@ -7,10 +7,8 @@ exports.wem2wav = wem2wav = async ({
   const util = require("util");
   const exec = util.promisify(require("child_process").execFile);
   const vgmstream = path.join(".", "libs", "vgmstream-cli.exe");
-  const outputFile = path.join(
-    outputDir,
-    createdFile.substr(0, createdFile.lastIndexOf('.')) + ".wav"
-  );
+  const fileNameNoExt = createdFile.substr(0, createdFile.lastIndexOf('.'));
+  const outputFile = path.join(outputDir, fileNameNoExt + ".wav");
   const createdFilePath = path.join(processingDir, createdFile);
 
   await exec(vgmstream, ["-o", outputFile, createdFilePath]);


### PR DESCRIPTION
- `--audio` now accepts possible audio formats to export to as intended. Solves https://github.com/MeguminSama/genshin-audio-extractor/issues/10.
- Apply https://github.com/MeguminSama/genshin-audio-extractor/pull/6 to all helper files.
- Add support for `ogg` audio format. Solves https://github.com/MeguminSama/genshin-audio-extractor/issues/12.

Replaced audio export option `flacandmp3` with `all` to include `ogg`.

I forgot to update the README to reflect those changes, apologies.